### PR TITLE
Add initial code for server

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -1,0 +1,39 @@
+import json
+
+CAR_PORT = 6006 # Assume each car is listening on this port
+
+def handle_movement(server, body, source):
+    print('MOVEMENT') # TODO: Logging
+    '''
+    TODO:
+    1. Get desination IP from cache (if not in cache, get from 'cars' table)
+    2. Forward the message
+    '''
+    data = json.dumps(body).encode('utf-8')
+    car_ip = 'localhost' # TODO: Make this read from cache or 'cars' table
+    server.send(data, (car_ip, CAR_PORT))
+
+def handle_register_user(server, body, source):
+    print('REGISTER USER') # TODO: Logging
+    '''
+    TODO:
+    1. Store username, salt, and salted-and-hashed-password in 'users' table
+    2. Send a confirmation (ACK) back to the app
+    '''
+
+def handle_register_car(server, body, source):
+    print('REGISTER CAR') # TODO: Logging
+    '''
+    TODO:
+    1. Add a row in the 'cars' table
+    2. Send a confirmation (ACK) back to the car
+    '''
+
+def handle_login(server, body, source):
+    print('LOGIN') # TODO: Logging
+    '''
+    TODO:
+    1. Compare salted-and-hashed passwords
+    2. If success: get car list from database and send to the app
+       If failure: send failed login message
+    '''

--- a/main.py
+++ b/main.py
@@ -1,0 +1,25 @@
+import argparse
+import handlers
+
+from enum import IntEnum
+from server import Server
+
+class MsgType(IntEnum):
+    REG_USER = 0
+    REG_CAR = 1
+    LOGIN = 2
+    MOVEMENT = 3
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='RC Camera Car Server.')
+    parser.add_argument('port', type=int, help='port to listen on')
+
+    args = parser.parse_args()
+    PORT = args.port
+    HOST = ''
+
+    server = Server(HOST, PORT)
+    server.add_handler(MsgType.REG_USER, handlers.handle_register_user)
+    server.add_handler(MsgType.REG_CAR, handlers.handle_register_car)
+    server.add_handler(MsgType.LOGIN, handlers.handle_login)
+    server.add_handler(MsgType.MOVEMENT, handlers.handle_movement)

--- a/server.py
+++ b/server.py
@@ -73,8 +73,8 @@ class Server(object):
 
     def get_destination(self, address):
         """
-        Get the cached destination address for that corresponds to a given
-        source address.
+        Get the cached destination address that corresponds to a given source
+        address.
         """
 
         return self.routes[address] if address in self.routes else None

--- a/server.py
+++ b/server.py
@@ -1,0 +1,88 @@
+import json
+import socket
+import threading
+
+class Server(object):
+    """
+    A class that encapsulates the UDP server for the Remote-Controlled Camera
+    Car system. This server uses a single UDP socket for all incoming and
+    outgoing messages. Once started, it will indefinitely listen on its single
+    socket, expecting all UDP messages to be JSON-formatted with a "type" which
+    it will use to decide which registered handler to call. This server also
+    makes its socket available for thread-safe sending.
+    """
+
+    BUFFER_SIZE = 100
+
+    def __init__(self, host, port):
+        """
+        Create a new UDP server that will listen forever on a single socket
+        bound to the given host and port.
+        """
+
+        self.routes = {}
+        self.handlers = {}
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.send_lock = threading.Lock()
+
+        self.socket.bind((host, port))
+        recv_thread = threading.Thread(target=self._receive_forever)
+        recv_thread.start()
+
+    def _receive_forever(self):
+        """
+        Start an infinite loop that will indefinitely block on a receive until
+        a new message comes in. If the message is JSON-formatted and has a
+        "type" key, then the corresponding handler will be run in a new thread.
+        """
+
+        while True:
+            data, addr = self.socket.recvfrom(self.BUFFER_SIZE)
+            try:
+                body = json.loads(data)
+            except json.JSONDecodeError:
+                print('Received invalid JSON') # TODO: Logging
+                continue
+            if body['type'] in self.handlers:
+                handler_thread = threading.Thread(
+                    target=self.handlers[body['type']],
+                    args=(self, body, addr)
+                )
+                handler_thread.start()
+            else:
+                print('Invalid message type', body)
+
+    def send(self, data, address):
+        """
+        Send a message containing the given data from the server's UDP socket
+        to the given address.
+        """
+
+        with self.send_lock:
+            self.socket.sendto(data, address)
+
+    def add_route(self, address1, address2):
+        """
+        Cache the source and destination addresses for a proxied-connection
+        between a client application and a car, with this server acting as the
+        proxy.
+        """
+
+        self.routes[address1] = address2
+        self.routes[address2] = address1
+
+    def get_destination(self, address):
+        """
+        Get the cached destination address for that corresponds to a given
+        source address.
+        """
+
+        return self.routes[address] if address in self.routes else None
+
+    def add_handler(self, message_type, handler):
+        """
+        Register a handler function that will be called whenever a message of
+        message_type is received.
+        """
+
+        self.handlers[message_type] = handler


### PR DESCRIPTION
This is one potential way of doing the core server code, where it only
uses a single UDP socket for all sending and receiving. The server spins
up a thread that will listen forever on the socket and then run
registered handlers in their own threads based on a "type" field in the
JSON-formatted messages that it receives (so this system assumes all
messages are valid JSON).

Ideally, this means that all of the database logic and response message
sending code can just be put into the handler functions.